### PR TITLE
Define bytesavailable for BufferStream.

### DIFF
--- a/src/BufferStream.jl
+++ b/src/BufferStream.jl
@@ -41,6 +41,7 @@ function length(bs::BufferStream)
         return len
     end
 end
+Base.bytesavailable(bs::BufferStream) = length(bs)
 function mem_usage(bs::BufferStream)
     lock(bs.write_cond) do
         return sum(Int[length(chunk) for chunk in bs.chunks])


### PR DESCRIPTION
I am not sure this is correct, but it feels like it should be. This is motivated by the following. In this example:
```julia
using HTTP, CodecZlib

const url = "https://pkg.julialang.org/artifact/ffddd41bc053989cee5c3fc4eaafd91c2cd32c58"

open("test.tar.gz", "w") do file
    HTTP.open("GET", url) do http
        while !eof(http)
            write(GzipCompressorStream(file), GzipDecompressorStream(http))
        end
    end
end
```
`HTTP.jl` throws a warning:
```
┌ Warning: Reading one byte at a time from HTTP.Stream is inefficient.
│ Use: io = BufferedInputStream(http::HTTP.Stream) instead.
│ See: https://github.com/BioJulia/BufferedStreams.jl
```

So I modified it to:
```julia
using HTTP, CodecZlib, SimpleBufferStream

const url = "https://pkg.julialang.org/artifact/ffddd41bc053989cee5c3fc4eaafd91c2cd32c58"

open("test2.tar.gz", "w") do file
    HTTP.open("GET", url) do http
        buf = BufferStream()
        while !eof(http)
            write(buf, http)
            write(GzipCompressorStream(file), GzipDecompressorStream(buf))
        end
    end
end
```
but that gives
```
ERROR: MethodError: no method matching bytesavailable(::BufferStream)
```


However, with this patch it still doesn't work, it deadlocks. What am I missing?