### PR TITLE
append_chunk: do not make a copy if the whole chunk is appended.

### DIFF
--- a/src/BufferStream.jl
+++ b/src/BufferStream.jl
@@ -67,7 +67,11 @@ function append_chunk(bs::BufferStream, data::AbstractVector{UInt8})
                 continue
             end
             bytes_to_write = min(space_available, length(data) - data_written)
-            push!(bs.chunks, data[data_written+1:data_written+bytes_to_write])
+            if data_written == 0 && bytes_to_write == length(data)
+                push!(bs.chunks, data)
+            else
+                push!(bs.chunks, data[data_written+1:data_written+bytes_to_write])
+            end
             # Notify someone who was waiting for some data
             lock(bs.read_cond) do
                 notify(bs.read_cond; all=false)


### PR DESCRIPTION
With
```julia
function perf(bytes)
    buf = BufferStream()
    @sync begin
        @async begin
            for i in 1:1024
                write(buf, bytes)
            end
            close(buf)
        end
        @async begin
            write(devnull, buf)
        end
    end
end
```

This goes from
```julia
julia> @btime perf($(rand(UInt8, 1024)));
  810.652 μs (19497 allocations: 2.69 MiB)

julia> @btime perf($(rand(UInt8, 1024^2)));
  349.328 ms (21545 allocations: 2.00 GiB)
```
to
```julia
julia> @btime perf($(rand(UInt8, 1024)));
  644.978 μs (17449 allocations: 1.52 MiB)

julia> @btime perf($(rand(UInt8, 1024^2)));
  119.063 ms (18473 allocations: 1.00 GiB)
```