### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleBufferStream"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [extras]
 Gzip_jll = "be1be57a-8558-53c3-a7e5-50095f79957e"


### PR DESCRIPTION
So we can release a new version since the LICENSE was added

Plus other changes since v1.1: https://github.com/JuliaPackaging/SimpleBufferStream.jl/compare/f17a220a3e3c7e2ddb47b4f6e6249ba6dcd39984...b1ffb927925b43264a5cc47b07a69f3aa9169cac